### PR TITLE
Add disk blob storage for MMS media

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,8 +18,10 @@ fi
 SBV_USER="$(getent passwd "${PUID}" | cut -d: -f1)"
 
 # Ensure data directory exists and has correct permissions
-mkdir -p "${DB_PATH_PREFIX:-/data}"
-chown -R "${SBV_USER}:${SBV_GROUP}" "${DB_PATH_PREFIX:-/data}"
+DATA_DIR="${DATA_DIR:-${DB_PATH_PREFIX:-/data}}"
+mkdir -p "${DATA_DIR}"
+chown -R "${SBV_USER}:${SBV_GROUP}" "${DATA_DIR}"
+export DATA_DIR
 
 # Log the user we're running as
 echo "Running as UID=${PUID} GID=${PGID} (${SBV_USER}:${SBV_GROUP})"

--- a/docs/superpowers/plans/2026-07-20-upload-mode-frontend.md
+++ b/docs/superpowers/plans/2026-07-20-upload-mode-frontend.md
@@ -1,0 +1,108 @@
+# Upload Mode Frontend Selector Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two inline radio buttons to the Upload modal so users can select `tempfile` or `pipe` upload mode, which is sent as the `upload_mode` form field on each upload.
+
+**Architecture:** Single file change to `frontend/src/components/Upload.jsx`. Add one new `uploadMode` state variable defaulted to `'tempfile'`, render two `Form.Check` radio buttons below the file list, and append the value to `FormData` in `uploadSingleFile`. No new files, no new dependencies.
+
+**Tech Stack:** React 19, React Bootstrap 2, Vite 7.
+
+## Global Constraints
+
+- Radio button values must be exactly `"tempfile"` and `"pipe"` (lowercase, verbatim — these are the strings the backend accepts)
+- Default selection: `"tempfile"`
+- Both radios must be disabled when `uploading === true`
+- Radios appear below the drop zone / file list, always visible
+- No new files, no new dependencies
+
+---
+
+### Task 1: Add upload mode radio buttons to Upload.jsx
+
+**Files:**
+- Modify: `frontend/src/components/Upload.jsx`
+
+**Interfaces:**
+- Consumes: existing `uploading` state (boolean), existing `uploadSingleFile` function, existing `FormData` construction in `uploadSingleFile`
+- Produces: `uploadMode` state (`'tempfile'` | `'pipe'`), radio UI, `upload_mode` form field on each POST
+
+- [ ] **Step 1: Add `uploadMode` state**
+
+In `Upload.jsx`, add the new state variable alongside the existing `useState` declarations (around line 8–17):
+
+```jsx
+const [uploadMode, setUploadMode] = useState('tempfile')
+```
+
+- [ ] **Step 2: Append `upload_mode` to FormData in `uploadSingleFile`**
+
+In `uploadSingleFile` (around line 116–117), update the FormData construction:
+
+```jsx
+const uploadSingleFile = async (file) => {
+  const formData = new FormData()
+  formData.append('file', file)
+  formData.append('upload_mode', uploadMode)
+  // ... rest unchanged
+```
+
+- [ ] **Step 3: Add the radio buttons to the JSX**
+
+After the file list block (the closing `</Form.Group>` tag around line 272) and before the closing `</div>` of the `mb-3` wrapper (around line 273), add:
+
+```jsx
+          <Form.Group className="mt-3">
+            <Form.Label className="small text-muted fw-semibold mb-1">Upload mode</Form.Label>
+            <div className="d-flex gap-3">
+              <Form.Check
+                type="radio"
+                id="mode-tempfile"
+                name="uploadMode"
+                label="Standard (temp file)"
+                value="tempfile"
+                checked={uploadMode === 'tempfile'}
+                onChange={() => setUploadMode('tempfile')}
+                disabled={uploading}
+              />
+              <Form.Check
+                type="radio"
+                id="mode-pipe"
+                name="uploadMode"
+                label="Streaming (pipe)"
+                value="pipe"
+                checked={uploadMode === 'pipe'}
+                onChange={() => setUploadMode('pipe')}
+                disabled={uploading}
+              />
+            </div>
+          </Form.Group>
+```
+
+- [ ] **Step 4: Lint**
+
+```bash
+cd /path/to/project/frontend && npm run lint
+```
+
+Expected: exits 0, no errors.
+
+- [ ] **Step 5: Manual smoke test**
+
+Start the dev server:
+```bash
+cd frontend && npm run dev
+```
+
+Open the app in a browser, trigger the Upload modal, and verify:
+- Two radio buttons appear below the file picker: "Standard (temp file)" (selected) and "Streaming (pipe)"
+- Clicking "Streaming (pipe)" selects it
+- Both radios become disabled while an upload is in progress
+- Selecting a file and uploading with "Streaming (pipe)" selected sends `upload_mode=pipe` in the form data (verify in browser DevTools → Network → the upload POST request payload)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/Upload.jsx
+git commit -m "feat: add upload mode radio buttons to upload modal"
+```

--- a/docs/superpowers/plans/2026-07-20-upload-mode-selection.md
+++ b/docs/superpowers/plans/2026-07-20-upload-mode-selection.md
@@ -1,0 +1,465 @@
+# Upload Mode Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `tempfile` / `pipe` upload processing mode selectable via CLI flag, env var, or per-request form field.
+
+**Architecture:** A package-level default mode in `internal/parser.go` is set at startup from CLI flag / env var. `HandleUpload` reads an optional `upload_mode` form field to override the default per-request, then branches: `tempfile` uses the existing temp-file path unchanged; `pipe` creates an `io.Pipe`, pumps the multipart reader into the writer in one goroutine, and calls the new `ProcessUploadedFileFromReader` from a second goroutine.
+
+**Tech Stack:** Go stdlib (`io`, `os`), Echo v4, existing `ParseSMSBackupStreaming(io.Reader)` API.
+
+## Global Constraints
+
+- Go module: `github.com/lowcarbdev/sbv`
+- Tests live in `internal/` as `package internal` (same package, white-box)
+- Run tests with: `go test ./internal/...`
+- Valid mode strings: `"tempfile"` and `"pipe"` (lowercase, exact)
+- Default mode when nothing is configured: `"tempfile"`
+- Invalid values at any config level are silently skipped; next level is tried
+- Invalid CLI/env value exits the process with a clear error message (same pattern as `--blob-storage`)
+
+---
+
+### Task 1: Add mode accessors and `ProcessUploadedFileFromReader` to `internal/parser.go`
+
+**Files:**
+- Modify: `internal/parser.go` (after line 789, end of file)
+- Test: `internal/parser_test.go`
+
+**Interfaces:**
+- Produces:
+  - `SetDefaultUploadMode(mode string)` — sets package-level default
+  - `GetDefaultUploadMode() string` — returns current default
+  - `ProcessUploadedFileFromReader(userID, username string, r io.Reader)` — same contract as `ProcessUploadedFile` but reads from `r` directly; no temp file created or deleted
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `internal/parser_test.go`:
+
+```go
+func TestDefaultUploadMode(t *testing.T) {
+	// Default should be tempfile
+	if got := GetDefaultUploadMode(); got != "tempfile" {
+		t.Errorf("expected default 'tempfile', got %q", got)
+	}
+}
+
+func TestSetDefaultUploadMode(t *testing.T) {
+	original := GetDefaultUploadMode()
+	defer SetDefaultUploadMode(original)
+
+	SetDefaultUploadMode("pipe")
+	if got := GetDefaultUploadMode(); got != "pipe" {
+		t.Errorf("expected 'pipe', got %q", got)
+	}
+
+	SetDefaultUploadMode("tempfile")
+	if got := GetDefaultUploadMode(); got != "tempfile" {
+		t.Errorf("expected 'tempfile', got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/... -run TestDefaultUploadMode -v
+go test ./internal/... -run TestSetDefaultUploadMode -v
+```
+
+Expected: FAIL with `undefined: GetDefaultUploadMode`
+
+- [ ] **Step 3: Add mode var and accessors to `internal/parser.go`**
+
+Add after the existing package-level vars (near `uploadProgress` / `uploadProgressLock`, around line 619):
+
+```go
+var defaultUploadMode = "tempfile"
+
+func SetDefaultUploadMode(mode string) {
+	defaultUploadMode = mode
+}
+
+func GetDefaultUploadMode() string {
+	return defaultUploadMode
+}
+```
+
+- [ ] **Step 4: Run accessor tests to verify they pass**
+
+```bash
+go test ./internal/... -run TestDefaultUploadMode -v
+go test ./internal/... -run TestSetDefaultUploadMode -v
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Write failing test for `ProcessUploadedFileFromReader`**
+
+Add to `internal/parser_test.go`. This test uses an in-memory SQLite DB the same way other parser tests do — look at `TestSampleXMLParsing` for the XML fixture. Because `ProcessUploadedFileFromReader` runs asynchronously (it's called in a goroutine by the handler), we call it directly and synchronously here.
+
+```go
+func TestProcessUploadedFileFromReader(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	if err := InitUserDB("test-user", dbPath); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	r := strings.NewReader(sampleXML)
+	// Call directly (not in goroutine) so we can observe results synchronously
+	processUploadedFileFromReaderSync("test-user", "testuser", r, db)
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM messages").Scan(&count); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 messages, got %d", count)
+	}
+}
+```
+
+Note: `processUploadedFileFromReaderSync` is an unexported helper we'll add that accepts a `*sql.DB` directly — it lets us test the core logic without the `GetUserDB` lookup. `ProcessUploadedFileFromReader` (exported, no DB param) is what the handler calls.
+
+Also add `"path/filepath"` and `"database/sql"` to imports in `parser_test.go` if not already present.
+
+- [ ] **Step 6: Run test to verify it fails**
+
+```bash
+go test ./internal/... -run TestProcessUploadedFileFromReader -v
+```
+
+Expected: FAIL with `undefined: processUploadedFileFromReaderSync`
+
+- [ ] **Step 7: Add `processUploadedFileFromReaderSync` and `ProcessUploadedFileFromReader` to `internal/parser.go`**
+
+Add after `ProcessUploadedFile` (after line 789):
+
+```go
+// processUploadedFileFromReaderSync is the testable core: parses r into userDB.
+func processUploadedFileFromReaderSync(userID, username string, r io.Reader, userDB *sql.DB) {
+	slog.Info("Starting pipe-mode processing", "user", username)
+
+	messageCount, callCount, err := ParseSMSBackupStreaming(userDB, userID, r, 1)
+	if err != nil {
+		slog.Error("Error processing file", "error", err)
+		SetUploadProgress(0, 0, "error")
+		uploadProgressLock.Lock()
+		if uploadProgress != nil {
+			uploadProgress.mu.Lock()
+			uploadProgress.ErrorMessage = fmt.Sprintf("Failed to process file: %v", err)
+			uploadProgress.mu.Unlock()
+		}
+		uploadProgressLock.Unlock()
+		return
+	}
+
+	slog.Info("Completed pipe-mode processing", "messages", messageCount, "calls", callCount)
+}
+
+// ProcessUploadedFileFromReader processes r in the background without writing a temp file.
+// Intended to be called in a goroutine; the caller is responsible for closing r on error.
+func ProcessUploadedFileFromReader(userID, username string, r io.Reader) {
+	slog.Info("Starting background pipe-mode processing", "user", username)
+
+	userDB, err := GetUserDB(userID, username)
+	if err != nil {
+		slog.Error("Error getting user database", "error", err)
+		SetUploadProgress(0, 0, "error")
+		uploadProgressLock.Lock()
+		if uploadProgress != nil {
+			uploadProgress.mu.Lock()
+			uploadProgress.ErrorMessage = fmt.Sprintf("Failed to get user database: %v", err)
+			uploadProgress.mu.Unlock()
+		}
+		uploadProgressLock.Unlock()
+		return
+	}
+
+	processUploadedFileFromReaderSync(userID, username, r, userDB)
+}
+```
+
+- [ ] **Step 8: Run all parser tests**
+
+```bash
+go test ./internal/... -run TestProcessUploadedFileFromReader -v
+go test ./internal/... -run TestDefaultUploadMode -v
+go test ./internal/... -run TestSetDefaultUploadMode -v
+```
+
+Expected: all PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/parser.go internal/parser_test.go
+git commit -m "feat: add upload mode accessors and ProcessUploadedFileFromReader"
+```
+
+---
+
+### Task 2: Wire `--upload-mode` flag and `UPLOAD_MODE` env var in `main.go`
+
+**Files:**
+- Modify: `main.go`
+
+**Interfaces:**
+- Consumes: `internal.SetDefaultUploadMode(string)` from Task 1
+- Produces: server starts with `defaultUploadMode` set to the resolved value
+
+- [ ] **Step 1: Add flag, resolve, validate, and call `SetDefaultUploadMode`**
+
+In `main.go`, after the `blobDir` flag (around line 23), add:
+
+```go
+uploadMode := flag.String("upload-mode", "", "Upload processing mode: 'tempfile' (default) or 'pipe'")
+```
+
+After the `blobDir` resolution block and before `internal.UseWALMode = ...`, add:
+
+```go
+resolvedUploadMode := *uploadMode
+if resolvedUploadMode == "" {
+    resolvedUploadMode = os.Getenv("UPLOAD_MODE")
+}
+if resolvedUploadMode == "" {
+    resolvedUploadMode = "tempfile"
+}
+if resolvedUploadMode != "tempfile" && resolvedUploadMode != "pipe" {
+    fmt.Fprintf(os.Stderr, "invalid --upload-mode value %q: must be 'tempfile' or 'pipe'\n", resolvedUploadMode)
+    os.Exit(1)
+}
+internal.SetDefaultUploadMode(resolvedUploadMode)
+```
+
+After the blob storage logger calls, add:
+
+```go
+logger.Info("Upload mode", "mode", resolvedUploadMode)
+```
+
+- [ ] **Step 2: Build to verify no compile errors**
+
+```bash
+go build ./...
+```
+
+Expected: exits 0, no output.
+
+- [ ] **Step 3: Smoke-test flag parsing**
+
+```bash
+./sbv --upload-mode=pipe --help 2>&1 | grep upload-mode || true
+go run . --upload-mode=invalid 2>&1 | grep "invalid --upload-mode"
+```
+
+Expected second line: prints `invalid --upload-mode value "invalid": must be 'tempfile' or 'pipe'`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add main.go
+git commit -m "feat: add --upload-mode flag and UPLOAD_MODE env var"
+```
+
+---
+
+### Task 3: Branch on mode in `HandleUpload` in `internal/handlers.go`
+
+**Files:**
+- Modify: `internal/handlers.go`
+
+**Interfaces:**
+- Consumes:
+  - `GetDefaultUploadMode() string` from Task 1
+  - `ProcessUploadedFileFromReader(userID, username string, r io.Reader)` from Task 1
+  - `SaveUploadedFile` and `ProcessUploadedFile` — unchanged, still used for `tempfile` mode
+
+- [ ] **Step 1: Write a failing handler test for pipe mode**
+
+Add to `internal/handlers_test.go`. Look at the existing upload test setup in that file for the multipart form builder pattern. Add:
+
+```go
+func TestHandleUploadPipeMode(t *testing.T) {
+	// Arrange: set pipe mode as default, restore after
+	SetDefaultUploadMode("pipe")
+	defer SetDefaultUploadMode("tempfile")
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "backup.xml")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	_, _ = io.WriteString(part, sampleXML)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.Set("user_id", testUserID)
+	c.Set("username", "testuser")
+
+	err = HandleUpload(c)
+	if err != nil {
+		t.Fatalf("HandleUpload: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UploadResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Success {
+		t.Errorf("expected success=true, got false: %s", resp.Error)
+	}
+	if !resp.Processing {
+		t.Errorf("expected processing=true")
+	}
+}
+```
+
+Check what `testUserID` and `testUsername` constants are called in `handlers_test.go` and use those exact names.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+go test ./internal/... -run TestHandleUploadPipeMode -v
+```
+
+Expected: FAIL (pipe branch not yet implemented; likely falls through to tempfile path or compile error).
+
+- [ ] **Step 3: Rewrite `HandleUpload` to branch on mode**
+
+Replace the body of `HandleUpload` in `internal/handlers.go` from after the `defer file.Close()` line to the end of the function:
+
+```go
+	slog.Info("Receiving file", "filename", header.Filename, "size", header.Size)
+
+	// Get user ID and username from context early — needed by both paths
+	userID, ok := c.Get("user_id").(string)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, UploadResponse{
+			Success: false,
+			Error:   "User not authenticated",
+		})
+	}
+	username, ok := c.Get("username").(string)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, UploadResponse{
+			Success: false,
+			Error:   "User not authenticated",
+		})
+	}
+
+	// Resolve effective mode: form field overrides server default
+	effectiveMode := GetDefaultUploadMode()
+	if formMode := c.Request().FormValue("upload_mode"); formMode == "pipe" || formMode == "tempfile" {
+		effectiveMode = formMode
+	}
+	slog.Info("Upload mode", "mode", effectiveMode, "filename", header.Filename)
+
+	if effectiveMode == "pipe" {
+		pr, pw := io.Pipe()
+		go func() {
+			_, err := io.Copy(pw, file)
+			pw.CloseWithError(err)
+		}()
+		go ProcessUploadedFileFromReader(userID, username, pr)
+	} else {
+		tempFilePath, err := SaveUploadedFile(file, header.Filename)
+		if err != nil {
+			slog.Error("Error saving file", "error", err)
+			return c.JSON(http.StatusInternalServerError, UploadResponse{
+				Success: false,
+				Error:   "Failed to save uploaded file: " + err.Error(),
+			})
+		}
+		slog.Info("File saved", "path", tempFilePath)
+		go ProcessUploadedFile(userID, username, tempFilePath)
+	}
+
+	return c.JSON(http.StatusOK, UploadResponse{
+		Success:      true,
+		MessageCount: 0,
+		CallLogCount: 0,
+		Processing:   true,
+	})
+```
+
+Also add `"io"` to the imports in `handlers.go` if not already present.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+go test ./internal/... -v 2>&1 | tail -30
+```
+
+Expected: all PASS, no FAIL lines.
+
+- [ ] **Step 5: Verify form field override works by adding a quick test**
+
+Add to `internal/handlers_test.go`:
+
+```go
+func TestHandleUploadFormFieldOverride(t *testing.T) {
+	// Server default is tempfile; form field requests pipe
+	SetDefaultUploadMode("tempfile")
+	defer SetDefaultUploadMode("tempfile")
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	_ = writer.WriteField("upload_mode", "pipe")
+	part, _ := writer.CreateFormFile("file", "backup.xml")
+	_, _ = io.WriteString(part, sampleXML)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.Set("user_id", testUserID)
+	c.Set("username", "testuser")
+
+	if err := HandleUpload(c); err != nil {
+		t.Fatalf("HandleUpload: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
+	}
+}
+```
+
+```bash
+go test ./internal/... -run TestHandleUploadFormFieldOverride -v
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite one final time**
+
+```bash
+go test ./internal/... -count=1
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/handlers.go internal/handlers_test.go
+git commit -m "feat: branch HandleUpload on pipe vs tempfile mode with form field override"
+```

--- a/docs/superpowers/specs/2026-07-20-upload-mode-design.md
+++ b/docs/superpowers/specs/2026-07-20-upload-mode-design.md
@@ -1,0 +1,100 @@
+# Upload Mode Selection Design
+
+**Date:** 2026-07-20  
+**Status:** Approved
+
+## Summary
+
+Add a user-selectable upload processing mode: `tempfile` (current behavior — write to disk then process) or `pipe` (stream directly via `io.Pipe`, no disk write). The mode is configurable at the server level via CLI flag / env var, and overridable per-request via a multipart form field.
+
+## Mode Descriptions
+
+### `tempfile` (default)
+Current behavior. The uploaded file is written to `os.TempDir()/sbv-uploads/backup-*.xml`, then a background goroutine opens and parses it, then deletes it.
+
+### `pipe`
+No disk write. The handler pumps the multipart reader into an `io.PipeWriter` in one goroutine; a second goroutine reads from the `io.PipeReader` and passes it to `ParseSMSBackupStreaming`. No temp file is created or deleted.
+
+## Configuration
+
+Priority (highest to lowest):
+
+1. Form field `upload_mode=pipe|tempfile` in the multipart POST body
+2. `--upload-mode` CLI flag
+3. `UPLOAD_MODE` environment variable
+4. Default: `tempfile`
+
+Invalid values at any level are ignored and the next level is tried.
+
+## Architecture
+
+### `main.go`
+
+- Add `--upload-mode` flag (string, default `""`)
+- Resolve with env var fallback to `UPLOAD_MODE`, then default to `tempfile`
+- Validate: must be `pipe` or `tempfile`
+- Pass resolved value to `internal.SetDefaultUploadMode(mode)`
+
+### `internal/handlers.go` — `HandleUpload`
+
+After parsing the multipart form, read the `upload_mode` form value. If it is `pipe` or `tempfile`, use it. Otherwise use the server default from `GetDefaultUploadMode()`.
+
+**`tempfile` path** (unchanged):
+```
+multipart reader → SaveUploadedFile → tempFilePath → go ProcessUploadedFile(userID, username, tempFilePath)
+```
+
+**`pipe` path** (new):
+```
+multipart reader
+  └─ goroutine A: io.Copy(pipeWriter, file); pipeWriter.CloseWithError(err)
+  └─ goroutine B: ProcessUploadedFileFromReader(userID, username, pipeReader)
+```
+
+Both paths return `HTTP 200` immediately with `Processing: true`. Progress is polled via `/api/progress` as before.
+
+### `internal/parser.go`
+
+- Add package-level `defaultUploadMode string` with `SetDefaultUploadMode` / `GetDefaultUploadMode` accessors.
+- Add `ProcessUploadedFileFromReader(userID, username string, r io.Reader)` — same body as `ProcessUploadedFile` but skips the `os.Open` and `os.Remove` steps, calling `ParseSMSBackupStreaming` directly with `r`.
+
+## Data Flow Diagram
+
+```
+POST /api/upload
+       │
+       ▼
+ParseMultipartForm (32 MB in-memory buffer)
+       │
+       ├── read upload_mode form field → resolve effective mode
+       │
+       ├── [tempfile] ──→ SaveUploadedFile ──→ go ProcessUploadedFile(path)
+       │                                              │
+       │                                    os.Open → ParseSMSBackupStreaming → os.Remove
+       │
+       └── [pipe] ──→ io.Pipe()
+                          ├── go: io.Copy(pw, file); pw.CloseWithError(err)
+                          └── go: ProcessUploadedFileFromReader(pr)
+                                        │
+                                  ParseSMSBackupStreaming(pr)
+```
+
+## Error Handling
+
+- **Pipe writer error** (e.g. client disconnect mid-upload): `pipeWriter.CloseWithError(err)` propagates to the reader; `xml.Decoder.Token()` returns the error; `ParseSMSBackupStreaming` returns it; progress is set to `error`.
+- **Invalid form field value**: silently ignored, server default is used.
+- **Invalid CLI/env value**: logged and process exits (same pattern as `--blob-storage`).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `main.go` | Add `--upload-mode` flag, resolve + validate, call `SetDefaultUploadMode` |
+| `internal/handlers.go` | Read form field, branch on effective mode |
+| `internal/parser.go` | Add `defaultUploadMode`, `SetDefaultUploadMode`, `GetDefaultUploadMode`, `ProcessUploadedFileFromReader` |
+
+## Non-Goals
+
+- No frontend UI to expose the mode selector (form field is available for power users / curl)
+- No per-user persistence of mode preference
+- No change to the progress polling mechanism

--- a/docs/superpowers/specs/2026-07-20-upload-mode-frontend-design.md
+++ b/docs/superpowers/specs/2026-07-20-upload-mode-frontend-design.md
@@ -1,0 +1,53 @@
+# Upload Mode Frontend Selector Design
+
+**Date:** 2026-07-20  
+**Status:** Approved
+
+## Summary
+
+Add two inline radio buttons to the Upload modal (`Upload.jsx`) so users can choose between `tempfile` (default) and `pipe` upload mode. The selected value is appended to the multipart form data on each upload, using the existing backend `upload_mode` form field.
+
+## UI
+
+Below the drop zone / file list, add a `Form.Group` with two `Form.Check` inline radio buttons:
+
+```
+Upload mode
+● Standard (temp file)   ○ Streaming (pipe)
+```
+
+- Default selection: `tempfile`
+- Both radios disabled while `uploading === true`
+- Visible at all times (not collapsed, not hidden)
+
+## State
+
+Add one new piece of local state:
+
+```js
+const [uploadMode, setUploadMode] = useState('tempfile')
+```
+
+State is local to the modal — resets to `'tempfile'` each time the modal is opened.
+
+## Data Flow
+
+In `uploadSingleFile`, append the mode to the form data before the POST:
+
+```js
+formData.append('upload_mode', uploadMode)
+```
+
+The backend already reads `upload_mode` from the multipart form and routes accordingly (see `internal/handlers.go`).
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/Upload.jsx` | Add `uploadMode` state, radio buttons UI, `formData.append` |
+
+## Non-Goals
+
+- No persistence of the user's mode preference across sessions
+- No explanation or help text for the two modes
+- No server round-trip to fetch the server default

--- a/frontend/src/components/Upload.jsx
+++ b/frontend/src/components/Upload.jsx
@@ -15,6 +15,7 @@ function Upload({ onClose, onSuccess }) {
   const [currentFileIndex, setCurrentFileIndex] = useState(0)
   const [totalFiles, setTotalFiles] = useState(0)
   const [isDragging, setIsDragging] = useState(false)
+  const [uploadMode, setUploadMode] = useState('tempfile')
 
   const handleFileChange = (e) => {
     const selectedFiles = Array.from(e.target.files)
@@ -115,6 +116,7 @@ function Upload({ onClose, onSuccess }) {
   const uploadSingleFile = async (file) => {
     const formData = new FormData()
     formData.append('file', file)
+    formData.append('upload_mode', uploadMode)
 
     setUploadProgress(0)
     setCurrentStep(1)
@@ -269,6 +271,32 @@ function Upload({ onClose, onSuccess }) {
                 </div>
               </div>
             )}
+          </Form.Group>
+
+          <Form.Group className="mt-3">
+            <Form.Label className="small text-muted fw-semibold mb-1">Upload mode</Form.Label>
+            <div className="d-flex gap-3">
+              <Form.Check
+                type="radio"
+                id="mode-tempfile"
+                name="uploadMode"
+                label="Standard (temp file)"
+                value="tempfile"
+                checked={uploadMode === 'tempfile'}
+                onChange={() => setUploadMode('tempfile')}
+                disabled={uploading}
+              />
+              <Form.Check
+                type="radio"
+                id="mode-pipe"
+                name="uploadMode"
+                label="Streaming (pipe)"
+                value="pipe"
+                checked={uploadMode === 'pipe'}
+                onChange={() => setUploadMode('pipe')}
+                disabled={uploading}
+              />
+            </div>
           </Form.Group>
         </div>
 

--- a/internal/auth_handlers.go
+++ b/internal/auth_handlers.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -82,7 +83,7 @@ func HandleRegister(c echo.Context) error {
 	if dbPathPrefix == "" {
 		dbPathPrefix = "."
 	}
-	userDBPath := fmt.Sprintf("%s/sbv_%s.db", dbPathPrefix, user.ID)
+	userDBPath := filepath.Join(dbPathPrefix, fmt.Sprintf("sbv_%s.db", user.ID))
 	if err := InitUserDB(user.ID, userDBPath); err != nil {
 		slog.Error("Error initializing user database", "error", err)
 		return echo.ErrInternalServerError

--- a/internal/autoimport.go
+++ b/internal/autoimport.go
@@ -167,7 +167,7 @@ func (s *AutoImportService) processFile(userID, filePath, filename string) {
 	var parseErr error
 	if strings.HasSuffix(strings.ToLower(filename), ".xml") {
 		logWriter.log("Detected XML backup file")
-		parseErr = s.parseXMLBackup(userDB, filePath, logWriter)
+		parseErr = s.parseXMLBackup(userID, userDB, filePath, logWriter)
 	} else {
 		logWriter.log("ERROR: Unsupported file type")
 		slog.Warn("Unsupported file type", "userID", userID, "file", filename)
@@ -248,7 +248,7 @@ func (s *AutoImportService) isFileStable(filePath string) bool {
 }
 
 // parseXMLBackup parses an XML backup file
-func (s *AutoImportService) parseXMLBackup(userDB *sql.DB, filePath string, logger *importLogger) error {
+func (s *AutoImportService) parseXMLBackup(userID string, userDB *sql.DB, filePath string, logger *importLogger) error {
 	logger.log("Parsing XML backup file")
 
 	file, err := os.Open(filePath)
@@ -263,7 +263,7 @@ func (s *AutoImportService) parseXMLBackup(userDB *sql.DB, filePath string, logg
 	logger.log("File size: %d bytes", fileSize)
 
 	// Parse the XML backup using streaming parser
-	totalProcessed, totalSkipped, err := ParseSMSBackupStreaming(userDB, file, 100)
+	totalProcessed, totalSkipped, err := ParseSMSBackupStreaming(userDB, userID, file, 100)
 	if err != nil {
 		return fmt.Errorf("failed to parse backup: %w", err)
 	}

--- a/internal/blobstore.go
+++ b/internal/blobstore.go
@@ -1,0 +1,193 @@
+package internal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// BlobStore abstracts where media blobs are persisted.
+type BlobStore interface {
+	// Write persists data and returns a relative file path, or "" if stored inline.
+	Write(data []byte, mediaType string) (filePath string, err error)
+	// Read retrieves data by the relative file path returned by Write.
+	Read(filePath string) (data []byte, mediaType string, err error)
+}
+
+// globalBlobStoreMu guards GlobalBlobStore for concurrent access.
+var globalBlobStoreMu sync.RWMutex
+
+// GlobalBlobStore is the shared store for all users.
+var GlobalBlobStore BlobStore = &DBBlobStore{}
+
+// GetGlobalBlobStore returns the current global BlobStore safely.
+func GetGlobalBlobStore() BlobStore {
+	globalBlobStoreMu.RLock()
+	defer globalBlobStoreMu.RUnlock()
+	return GlobalBlobStore
+}
+
+// SetGlobalBlobStore sets the global BlobStore safely.
+func SetGlobalBlobStore(s BlobStore) {
+	globalBlobStoreMu.Lock()
+	defer globalBlobStoreMu.Unlock()
+	GlobalBlobStore = s
+}
+
+// DBBlobStore is a no-op: blobs are stored inline in media_data.
+type DBBlobStore struct{}
+
+func (d *DBBlobStore) Write(_ []byte, _ string) (string, error) { return "", nil }
+func (d *DBBlobStore) Read(_ string) ([]byte, string, error)    { return nil, "", nil }
+
+var mimeToExt = map[string]string{
+	"image/jpeg":      ".jpg",
+	"image/png":       ".png",
+	"image/gif":       ".gif",
+	"image/webp":      ".webp",
+	"image/heic":      ".heic",
+	"image/heif":      ".heif",
+	"video/mp4":       ".mp4",
+	"video/3gpp":      ".3gp",
+	"video/quicktime": ".mov",
+	"audio/mpeg":      ".mp3",
+	"audio/amr":       ".amr",
+	"audio/ogg":       ".ogg",
+	"audio/aac":       ".aac",
+	"text/vcard":      ".vcf",
+	"text/x-vcard":    ".vcf",
+}
+
+var extToMime = map[string]string{
+	".jpg":  "image/jpeg",
+	".png":  "image/png",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+	".heic": "image/heic",
+	".heif": "image/heif",
+	".mp4":  "video/mp4",
+	".3gp":  "video/3gpp",
+	".mov":  "video/quicktime",
+	".mp3":  "audio/mpeg",
+	".amr":  "audio/amr",
+	".ogg":  "audio/ogg",
+	".aac":  "audio/aac",
+	".vcf":  "text/vcard",
+}
+
+var safeExt = regexp.MustCompile(`[^a-z0-9._-]`)
+
+func mediaTypeToExt(mediaType string) string {
+	if mediaType == "" {
+		return ".bin"
+	}
+	// Strip parameters (e.g. "image/jpeg; charset=utf-8" -> "image/jpeg")
+	base := strings.ToLower(strings.SplitN(mediaType, ";", 2)[0])
+	base = strings.TrimSpace(base)
+	if ext, ok := mimeToExt[base]; ok {
+		return ext
+	}
+	// Derive from subtype
+	parts := strings.SplitN(base, "/", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return ".bin"
+	}
+	ext := "." + safeExt.ReplaceAllString(parts[1], "")
+	if ext == "." {
+		return ".bin"
+	}
+	return ext
+}
+
+func extToMediaType(ext string) string {
+	// Accept both ".jpg" and "path/to/file.jpg"
+	if !strings.HasPrefix(ext, ".") {
+		ext = filepath.Ext(ext)
+	}
+	ext = strings.ToLower(ext)
+	if mt, ok := extToMime[ext]; ok {
+		return mt
+	}
+	return "application/octet-stream"
+}
+
+// DiskBlobStore stores blobs as <sha256-hash>.<ext> files under baseDir.
+type DiskBlobStore struct {
+	baseDir string
+}
+
+// NewDiskBlobStore creates a DiskBlobStore using sha256 for content-addressable filenames.
+func NewDiskBlobStore(baseDir string) *DiskBlobStore {
+	return &DiskBlobStore{baseDir: baseDir}
+}
+
+func (d *DiskBlobStore) Write(data []byte, mediaType string) (string, error) {
+	if err := os.MkdirAll(d.baseDir, 0755); err != nil {
+		return "", fmt.Errorf("blobstore: mkdir %s: %w", d.baseDir, err)
+	}
+
+	h := sha256.New()
+	h.Write(data)
+	hexHash := hex.EncodeToString(h.Sum(nil))
+	ext := mediaTypeToExt(mediaType)
+	filename := hexHash + ext
+	fullPath := filepath.Join(d.baseDir, filename)
+
+	// Dedup: if file already exists, skip write
+	if _, err := os.Stat(fullPath); err == nil {
+		return filename, nil
+	}
+
+	// Write atomically: temp file in same dir, then rename
+	tmp, err := os.CreateTemp(d.baseDir, "blob-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("blobstore: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	_, writeErr := tmp.Write(data)
+	closeErr := tmp.Close()
+	if writeErr != nil || closeErr != nil {
+		os.Remove(tmpName)
+		if writeErr != nil {
+			return "", fmt.Errorf("blobstore: write temp: %w", writeErr)
+		}
+		return "", fmt.Errorf("blobstore: close temp: %w", closeErr)
+	}
+
+	if err := os.Rename(tmpName, fullPath); err != nil {
+		os.Remove(tmpName)
+		return "", fmt.Errorf("blobstore: rename to %s: %w", fullPath, err)
+	}
+
+	slog.Debug("BlobStore wrote file", "path", fullPath, "size", len(data))
+	return filename, nil
+}
+
+// SetModTime sets the modification time of a blob file to match the message timestamp.
+func (d *DiskBlobStore) SetModTime(filePath string, t time.Time) error {
+	return os.Chtimes(filepath.Join(d.baseDir, filePath), t, t)
+}
+
+func (d *DiskBlobStore) Read(filePath string) ([]byte, string, error) {
+	fullPath := filepath.Join(d.baseDir, filePath)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, "", fmt.Errorf("blobstore: read %s: %w", fullPath, err)
+	}
+	ext := filepath.Ext(filePath)
+	mediaType := extToMediaType(ext)
+	return data, mediaType, nil
+}
+
+// GetUserBlobStore returns the shared BlobStore for all users.
+func GetUserBlobStore(_ string) BlobStore {
+	return GetGlobalBlobStore()
+}

--- a/internal/blobstore_test.go
+++ b/internal/blobstore_test.go
@@ -1,0 +1,400 @@
+package internal
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestDBBlobStoreWrite(t *testing.T) {
+	s := &DBBlobStore{}
+	path, err := s.Write([]byte("data"), "image/jpeg")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "" {
+		t.Errorf("expected empty path, got %q", path)
+	}
+}
+
+func TestDBBlobStoreRead(t *testing.T) {
+	s := &DBBlobStore{}
+	data, mediaType, err := s.Read("anything")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data != nil {
+		t.Errorf("expected nil data")
+	}
+	if mediaType != "" {
+		t.Errorf("expected empty mediaType, got %q", mediaType)
+	}
+}
+
+func TestMediaTypeToExt(t *testing.T) {
+	cases := []struct {
+		mime string
+		ext  string
+	}{
+		{"image/jpeg", ".jpg"},
+		{"image/png", ".png"},
+		{"image/gif", ".gif"},
+		{"image/webp", ".webp"},
+		{"image/heic", ".heic"},
+		{"image/heif", ".heif"},
+		{"video/mp4", ".mp4"},
+		{"video/3gpp", ".3gp"},
+		{"video/quicktime", ".mov"},
+		{"audio/mpeg", ".mp3"},
+		{"audio/amr", ".amr"},
+		{"audio/ogg", ".ogg"},
+		{"audio/aac", ".aac"},
+		{"text/vcard", ".vcf"},
+		{"text/x-vcard", ".vcf"},
+		{"image/jpeg; charset=utf-8", ".jpg"},
+		{"image/x-custom", ".x-custom"},
+		{"application/octet-stream", ".octet-stream"},
+		{"", ".bin"},
+	}
+	for _, c := range cases {
+		got := mediaTypeToExt(c.mime)
+		if got != c.ext {
+			t.Errorf("mediaTypeToExt(%q) = %q, want %q", c.mime, got, c.ext)
+		}
+	}
+}
+
+func TestExtToMediaType(t *testing.T) {
+	cases := []struct {
+		ext      string
+		expected string
+	}{
+		{".jpg", "image/jpeg"},
+		{".png", "image/png"},
+		{".mp4", "video/mp4"},
+		{".mp3", "audio/mpeg"},
+		{".vcf", "text/vcard"},
+		{".unknown", "application/octet-stream"},
+		{"", "application/octet-stream"},
+	}
+	for _, c := range cases {
+		got := extToMediaType(c.ext)
+		if got != c.expected {
+			t.Errorf("extToMediaType(%q) = %q, want %q", c.ext, got, c.expected)
+		}
+	}
+}
+
+func TestDiskBlobStoreRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewDiskBlobStore(dir)
+
+	data := []byte("hello media")
+	mediaType := "image/jpeg"
+
+	path, err := s.Write(data, mediaType)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+	if !strings.HasSuffix(path, ".jpg") {
+		t.Errorf("expected .jpg extension, got %q", path)
+	}
+
+	got, gotType, err := s.Read(path)
+	if err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("data mismatch: got %q, want %q", got, data)
+	}
+	if gotType != mediaType {
+		t.Errorf("mediaType mismatch: got %q, want %q", gotType, mediaType)
+	}
+}
+
+func TestDiskBlobStoreDedup(t *testing.T) {
+	dir := t.TempDir()
+	s := NewDiskBlobStore(dir)
+
+	data := []byte("duplicate content")
+	path1, err := s.Write(data, "image/png")
+	if err != nil {
+		t.Fatalf("first Write failed: %v", err)
+	}
+	path2, err := s.Write(data, "image/png")
+	if err != nil {
+		t.Fatalf("second Write failed: %v", err)
+	}
+	if path1 != path2 {
+		t.Errorf("expected same path for duplicate, got %q and %q", path1, path2)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("expected 1 file on disk, got %d", len(entries))
+	}
+}
+
+
+func TestDiskBlobStoreReadMissing(t *testing.T) {
+	dir := t.TempDir()
+	s := NewDiskBlobStore(dir)
+	_, _, err := s.Read("nonexistent.jpg")
+	if err == nil {
+		t.Error("expected error reading nonexistent file")
+	}
+}
+
+func TestGetUserBlobStore(t *testing.T) {
+	dir := t.TempDir()
+	s := NewDiskBlobStore(dir)
+	SetGlobalBlobStore(s)
+	defer func() { SetGlobalBlobStore(&DBBlobStore{}) }()
+
+	store := GetUserBlobStore("user-abc")
+	if store != s {
+		t.Error("expected GlobalBlobStore to be returned")
+	}
+}
+
+func TestAddMediaFilePathColumn(t *testing.T) {
+	// Test that the column is added on a fresh DB and is idempotent on repeated calls
+	tmpDB := filepath.Join(t.TempDir(), "test.db")
+	testDB, err := sql.Open("sqlite3", tmpDB)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer testDB.Close()
+
+	// Create minimal messages table without media_file_path
+	_, err = testDB.Exec(`CREATE TABLE messages (
+		id INTEGER PRIMARY KEY,
+		media_data BLOB,
+		media_type TEXT
+	)`)
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	// First call should add the column
+	if err := addMediaFilePathColumn(testDB); err != nil {
+		t.Fatalf("first addMediaFilePathColumn: %v", err)
+	}
+
+	// Second call should be a no-op (idempotent)
+	if err := addMediaFilePathColumn(testDB); err != nil {
+		t.Fatalf("second addMediaFilePathColumn: %v", err)
+	}
+
+	// Verify column exists by inserting a row with it
+	_, err = testDB.Exec(`INSERT INTO messages (id, media_file_path) VALUES (1, 'test.jpg')`)
+	if err != nil {
+		t.Fatalf("insert with media_file_path: %v", err)
+	}
+}
+
+// setupMessagesTable creates the messages table (full schema) and adds the
+// media_file_path column plus an FTS virtual table, so tests can call InsertMessage.
+func setupMessagesTable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS messages (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		record_type INTEGER NOT NULL DEFAULT 1,
+		address TEXT NOT NULL,
+		body TEXT,
+		type INTEGER NOT NULL,
+		date INTEGER NOT NULL,
+		read INTEGER DEFAULT 0,
+		thread_id INTEGER,
+		subject TEXT,
+		media_type TEXT,
+		media_data BLOB,
+		protocol INTEGER,
+		status INTEGER,
+		service_center TEXT,
+		sub_id INTEGER,
+		contact_name TEXT,
+		sender TEXT,
+		content_type TEXT,
+		read_report INTEGER,
+		read_status INTEGER,
+		message_id TEXT,
+		message_size INTEGER,
+		message_type INTEGER,
+		sim_slot INTEGER,
+		addresses TEXT,
+		duration INTEGER,
+		presentation INTEGER,
+		subscription_id TEXT
+	)`)
+	if err != nil {
+		t.Fatalf("create messages table: %v", err)
+	}
+	if err := addMediaFilePathColumn(db); err != nil {
+		t.Fatalf("addMediaFilePathColumn: %v", err)
+	}
+	// FTS table needed for InsertMessage triggers
+	_, _ = db.Exec(`CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+		message_id UNINDEXED, address UNINDEXED, body, contact_name UNINDEXED, date UNINDEXED,
+		content='messages', content_rowid='id'
+	)`)
+}
+
+func TestGetMessageMediaFallback(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	testDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer testDB.Close()
+	setupMessagesTable(t, testDB)
+
+	fakeMedia := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	msg := &Message{
+		Address:     "+15551234567",
+		Body:        "test",
+		Type:        1,
+		Date:        time.Now(),
+		MediaType:   "image/jpeg",
+		MediaData:   fakeMedia,
+		ContentType: "application/vnd.wap.multipart.related",
+	}
+	if err := InsertMessage(testDB, msg); err != nil {
+		t.Fatalf("InsertMessage: %v", err)
+	}
+
+	// Use DBBlobStore (default) — should serve from media_data
+	SetGlobalBlobStore(&DBBlobStore{})
+
+	gotData, gotType, err := GetMessageMedia(testDB, "test-user", fmt.Sprintf("%d", msg.ID))
+	if err != nil {
+		t.Fatalf("GetMessageMedia: %v", err)
+	}
+	if string(gotData) != string(fakeMedia) {
+		t.Error("data mismatch")
+	}
+	if gotType != "image/jpeg" {
+		t.Errorf("type = %q, want image/jpeg", gotType)
+	}
+}
+
+func TestGetMessageMediaNeither(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	testDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer testDB.Close()
+	setupMessagesTable(t, testDB)
+
+	// Insert message with no media
+	msg := &Message{
+		Address:     "+15551234567",
+		Body:        "no media here",
+		Type:        1,
+		Date:        time.Now(),
+		ContentType: "application/vnd.wap.multipart.related",
+	}
+	if err := InsertMessage(testDB, msg); err != nil {
+		t.Fatalf("InsertMessage: %v", err)
+	}
+
+	_, _, err = GetMessageMedia(testDB, "test-user", fmt.Sprintf("%d", msg.ID))
+	if err == nil {
+		t.Error("expected error for message with no media")
+	}
+}
+
+
+func TestInsertMessageWithDiskBlobStore(t *testing.T) {
+	// Setup: temp dir, real SQLite DB, DiskBlobStore configured
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	testDB, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer testDB.Close()
+
+	setupMessagesTable(t, testDB)
+
+	// Configure disk blob store
+	blobDir := filepath.Join(dir, "media")
+	var store BlobStore = NewDiskBlobStore(blobDir)
+	SetGlobalBlobStore(store)
+	defer func() { SetGlobalBlobStore(&DBBlobStore{}) }()
+
+	fakeMedia := []byte{0xFF, 0xD8, 0xFF, 0xE0} // JPEG magic bytes
+	msg := &Message{
+		Address:     "+15551234567",
+		Body:        "test",
+		Type:        1,
+		Date:        time.Now(),
+		MediaType:   "image/jpeg",
+		MediaData:   fakeMedia,
+		ContentType: "application/vnd.wap.multipart.related",
+	}
+
+	// Simulate what ParseSMSBackupStreaming does
+	if msg.MediaData != nil {
+		if _, isDB := store.(*DBBlobStore); !isDB {
+			filePath, blobErr := store.Write(msg.MediaData, msg.MediaType)
+			if blobErr != nil {
+				t.Fatalf("blob write: %v", blobErr)
+			}
+			msg.MediaFilePath = filePath
+			msg.MediaData = nil
+		}
+	}
+
+	if err := InsertMessage(testDB, msg); err != nil {
+		t.Fatalf("InsertMessage: %v", err)
+	}
+
+	// Verify: media_data is NULL in DB
+	var mediaData []byte
+	var mediaFilePath string
+	row := testDB.QueryRow("SELECT media_data, COALESCE(media_file_path,'') FROM messages WHERE id = ?", msg.ID)
+	if err := row.Scan(&mediaData, &mediaFilePath); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if mediaData != nil {
+		t.Error("expected media_data to be NULL in DB")
+	}
+	if mediaFilePath == "" {
+		t.Error("expected media_file_path to be set")
+	}
+
+	// Verify: file exists on disk
+	diskPath := filepath.Join(blobDir, mediaFilePath)
+	diskData, err := os.ReadFile(diskPath)
+	if err != nil {
+		t.Fatalf("read disk file: %v", err)
+	}
+	if string(diskData) != string(fakeMedia) {
+		t.Error("disk file content mismatch")
+	}
+
+	// Verify: GetMessageMedia reads it back correctly
+	gotData, gotType, err := GetMessageMedia(testDB, "test-user", fmt.Sprintf("%d", msg.ID))
+	if err != nil {
+		t.Fatalf("GetMessageMedia: %v", err)
+	}
+	if string(gotData) != string(fakeMedia) {
+		t.Error("GetMessageMedia data mismatch")
+	}
+	if gotType != "image/jpeg" {
+		t.Errorf("GetMessageMedia type = %q, want image/jpeg", gotType)
+	}
+}

--- a/internal/database.go
+++ b/internal/database.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -155,6 +156,10 @@ func InitDB(filepath string) error {
 		return err
 	}
 
+	if err = addMediaFilePathColumn(db); err != nil {
+		return fmt.Errorf("failed to add media_file_path column: %w", err)
+	}
+
 	slog.Info("Database initialized successfully")
 	return nil
 }
@@ -261,6 +266,10 @@ func InitUserDB(userID string, filepath string) error {
 		return err
 	}
 
+	if err = addMediaFilePathColumn(userDB); err != nil {
+		return fmt.Errorf("failed to add media_file_path column: %w", err)
+	}
+
 	// Store in map
 	userDBsMutex.Lock()
 	userDBs[userID] = userDB
@@ -268,6 +277,35 @@ func InitUserDB(userID string, filepath string) error {
 
 	slog.Info("User database initialized", "user_id", userID, "path", filepath)
 	return nil
+}
+
+// addMediaFilePathColumn adds the media_file_path column to messages if it doesn't exist.
+func addMediaFilePathColumn(db *sql.DB) error {
+	rows, err := db.Query("PRAGMA table_info(messages)")
+	if err != nil {
+		return fmt.Errorf("PRAGMA table_info: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull int
+		var dfltValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			return err
+		}
+		if name == "media_file_path" {
+			return nil // already exists
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	_, err = db.Exec("ALTER TABLE messages ADD COLUMN media_file_path TEXT")
+	return err
 }
 
 // GetUserDB retrieves the database connection for a specific user, creating it if it doesn't exist
@@ -283,10 +321,10 @@ func GetUserDB(userID string, username string) (*sql.DB, error) {
 			dbPathPrefix = "."
 		}
 		// Use UUID as database filename instead of sanitized username
-		filepath := fmt.Sprintf("%s/sbv_%s.db", dbPathPrefix, userID)
+		dbPath := filepath.Join(dbPathPrefix, fmt.Sprintf("sbv_%s.db", userID))
 
 		// InitUserDB will create the database if it doesn't exist
-		if err := InitUserDB(userID, filepath); err != nil {
+		if err := InitUserDB(userID, dbPath); err != nil {
 			return nil, fmt.Errorf("failed to initialize user database: %w", err)
 		}
 
@@ -318,13 +356,14 @@ func InsertMessage(userDB *sql.DB, msg *Message) error {
 		INSERT INTO messages (
 			record_type, address, body, type, date, read, thread_id, subject, media_type, media_data,
 			protocol, status, service_center, sub_id, contact_name, sender,
-			content_type, read_report, read_status, message_id, message_size, message_type, sim_slot, addresses
+			content_type, read_report, read_status, message_id, message_size, message_type, sim_slot, addresses,
+			media_file_path
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT DO NOTHING
 	`
 	result, err := userDB.Exec(query,
-		recordType, // record_type: 1 = SMS, 2 = MMS
+		recordType,
 		msg.Address,
 		msg.Body,
 		msg.Type,
@@ -348,6 +387,7 @@ func InsertMessage(userDB *sql.DB, msg *Message) error {
 		msg.MessageType,
 		msg.SimSlot,
 		addressesJSON,
+		msg.MediaFilePath,
 	)
 	if err != nil {
 		slog.Debug("InsertMessage: Error inserting message", "error", err)
@@ -925,26 +965,44 @@ func GetMediaByAddress(userDB *sql.DB, address string, startDate, endDate *time.
 	return mediaItems, nil
 }
 
-func GetMessageMedia(userDB *sql.DB, messageID string) ([]byte, string, error) {
+func GetMessageMedia(userDB *sql.DB, userID string, messageID string) ([]byte, string, error) {
 	query := `
-		SELECT COALESCE(media_data, ''), COALESCE(media_type, '')
+		SELECT COALESCE(media_data, x''), COALESCE(media_type, ''), COALESCE(media_file_path, '')
 		FROM messages
 		WHERE id = ? AND record_type IN (1, 2)  -- 1 = SMS, 2 = MMS
 	`
 
 	slog.Debug("GetMessageMedia: Fetching media", "message_id", messageID)
-	slog.Debug("GetMessageMedia: SQL query", "query", query)
 
 	var mediaData []byte
 	var mediaType string
+	var mediaFilePath string
 
-	err := userDB.QueryRow(query, messageID).Scan(&mediaData, &mediaType)
+	err := userDB.QueryRow(query, messageID).Scan(&mediaData, &mediaType, &mediaFilePath)
 	if err != nil {
 		slog.Debug("GetMessageMedia: Error scanning row", "message_id", messageID, "error", err)
 		return nil, "", err
 	}
 
 	slog.Debug("GetMessageMedia: Found media", "media_type", mediaType, "data_length", len(mediaData), "message_id", messageID)
+
+	// Resolve bytes: file path takes priority over inline blob (legacy fallback)
+	if mediaFilePath != "" {
+		store := GetUserBlobStore(userID)
+		if _, isDB := store.(*DBBlobStore); isDB {
+			slog.Warn("GetMessageMedia: media_file_path set but blob storage is 'db' mode — check BLOB_STORAGE config", "path", mediaFilePath, "message_id", messageID)
+			return nil, "", fmt.Errorf("no media found")
+		}
+		fileData, fileMediaType, err := store.Read(mediaFilePath)
+		if err != nil {
+			slog.Error("GetMessageMedia: failed to read blob file", "path", mediaFilePath, "error", err)
+			return nil, "", fmt.Errorf("no media found")
+		}
+		if fileMediaType != "" {
+			mediaType = fileMediaType
+		}
+		mediaData = fileData
+	}
 
 	if len(mediaData) == 0 || mediaType == "" {
 		slog.Debug("GetMessageMedia: No media found", "message_id", messageID)

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -48,7 +48,6 @@ func HandleUpload(c echo.Context) error {
 			Error:   "Failed to get file from form",
 		})
 	}
-	defer file.Close()
 
 	slog.Info("Receiving file", "filename", header.Filename, "size", header.Size)
 
@@ -79,11 +78,13 @@ func HandleUpload(c echo.Context) error {
 		pr, pw := io.Pipe()
 		go func() {
 			_, err := io.Copy(pw, file)
+			file.Close()
 			pw.CloseWithError(err)
 		}()
 		go ProcessUploadedFileFromReader(userID, username, pr)
 	} else {
 		tempFilePath, err := SaveUploadedFile(file, header.Filename)
+		file.Close()
 		if err != nil {
 			slog.Error("Error saving file", "error", err)
 			return c.JSON(http.StatusInternalServerError, UploadResponse{

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -54,6 +54,7 @@ func HandleUpload(c echo.Context) error {
 	// Get user ID and username from context early — needed by both paths
 	userID, ok := c.Get("user_id").(string)
 	if !ok {
+		file.Close()
 		return c.JSON(http.StatusUnauthorized, UploadResponse{
 			Success: false,
 			Error:   "User not authenticated",
@@ -61,6 +62,7 @@ func HandleUpload(c echo.Context) error {
 	}
 	username, ok := c.Get("username").(string)
 	if !ok {
+		file.Close()
 		return c.JSON(http.StatusUnauthorized, UploadResponse{
 			Success: false,
 			Error:   "User not authenticated",

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -448,8 +448,13 @@ func HandleMedia(c echo.Context) error {
 	// Check if transcode is requested (for videos that browser can't play)
 	forceTranscode := c.QueryParam("transcode") == "true"
 
+	userID, ok := c.Get("user_id").(string)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, map[string]string{"error": "User not authenticated"})
+	}
+
 	// Fetch media from database
-	media, contentType, err := GetMessageMedia(userDB, messageID)
+	media, contentType, err := GetMessageMedia(userDB, userID, messageID)
 	if err != nil {
 		slog.Error("Error getting media", "error", err)
 		return c.JSON(http.StatusNotFound, map[string]string{

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -51,19 +52,7 @@ func HandleUpload(c echo.Context) error {
 
 	slog.Info("Receiving file", "filename", header.Filename, "size", header.Size)
 
-	// Save uploaded file to temporary location first
-	tempFilePath, err := SaveUploadedFile(file, header.Filename)
-	if err != nil {
-		slog.Error("Error saving file", "error", err)
-		return c.JSON(http.StatusInternalServerError, UploadResponse{
-			Success: false,
-			Error:   "Failed to save uploaded file: " + err.Error(),
-		})
-	}
-
-	slog.Info("File saved", "path", tempFilePath)
-
-	// Get user ID from context
+	// Get user ID and username from context early — needed by both paths
 	userID, ok := c.Get("user_id").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, UploadResponse{
@@ -71,8 +60,6 @@ func HandleUpload(c echo.Context) error {
 			Error:   "User not authenticated",
 		})
 	}
-
-	// Get username from context
 	username, ok := c.Get("username").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, UploadResponse{
@@ -81,10 +68,33 @@ func HandleUpload(c echo.Context) error {
 		})
 	}
 
-	// Start background processing with user context
-	go ProcessUploadedFile(userID, username, tempFilePath)
+	// Resolve effective mode: form field overrides server default
+	effectiveMode := GetDefaultUploadMode()
+	if formMode := c.Request().FormValue("upload_mode"); formMode == "pipe" || formMode == "tempfile" {
+		effectiveMode = formMode
+	}
+	slog.Info("Upload mode", "mode", effectiveMode, "filename", header.Filename)
 
-	// Return immediately - client will poll /api/progress for status
+	if effectiveMode == "pipe" {
+		pr, pw := io.Pipe()
+		go func() {
+			_, err := io.Copy(pw, file)
+			pw.CloseWithError(err)
+		}()
+		go ProcessUploadedFileFromReader(userID, username, pr)
+	} else {
+		tempFilePath, err := SaveUploadedFile(file, header.Filename)
+		if err != nil {
+			slog.Error("Error saving file", "error", err)
+			return c.JSON(http.StatusInternalServerError, UploadResponse{
+				Success: false,
+				Error:   "Failed to save uploaded file: " + err.Error(),
+			})
+		}
+		slog.Info("File saved", "path", tempFilePath)
+		go ProcessUploadedFile(userID, username, tempFilePath)
+	}
+
 	return c.JSON(http.StatusOK, UploadResponse{
 		Success:      true,
 		MessageCount: 0,

--- a/internal/handlers_test.go
+++ b/internal/handlers_test.go
@@ -1,8 +1,11 @@
 package internal
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -566,5 +569,83 @@ func TestGetUserDBHelperMissingUsername(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "username not found") {
 		t.Errorf("Expected error about missing username, got: %v", err)
+	}
+}
+
+func TestHandleUploadPipeMode(t *testing.T) {
+	_, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Arrange: set pipe mode as default, restore after
+	SetDefaultUploadMode("pipe")
+	defer SetDefaultUploadMode("tempfile")
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "backup.xml")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	_, _ = io.WriteString(part, sampleXML)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.Set("user_id", testUserID)
+	c.Set("username", "testuser")
+
+	err = HandleUpload(c)
+	if err != nil {
+		t.Fatalf("HandleUpload: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp UploadResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Success {
+		t.Errorf("expected success=true, got false: %s", resp.Error)
+	}
+	if !resp.Processing {
+		t.Errorf("expected processing=true")
+	}
+}
+
+func TestHandleUploadFormFieldOverride(t *testing.T) {
+	_, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Server default is tempfile; form field requests pipe
+	SetDefaultUploadMode("tempfile")
+	defer SetDefaultUploadMode("tempfile")
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	_ = writer.WriteField("upload_mode", "pipe")
+	part, _ := writer.CreateFormFile("file", "backup.xml")
+	_, _ = io.WriteString(part, sampleXML)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/upload", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.Set("user_id", testUserID)
+	c.Set("username", "testuser")
+
+	if err := HandleUpload(c); err != nil {
+		t.Fatalf("HandleUpload: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rec.Code)
 	}
 }

--- a/internal/models.go
+++ b/internal/models.go
@@ -13,8 +13,9 @@ type Message struct {
 	ThreadID    int       `json:"thread_id"`
 	Subject     string    `json:"subject,omitempty"`
 	MediaType   string    `json:"media_type,omitempty"`
-	MediaData   []byte    `json:"-"`
-	MediaBase64 string    `json:"media_base64,omitempty"`
+	MediaData     []byte `json:"-"`
+	MediaFilePath string `json:"-"`
+	MediaBase64   string `json:"media_base64,omitempty"`
 	// Additional SMS fields
 	Protocol      int    `json:"protocol,omitempty"`
 	Status        int    `json:"status,omitempty"` // -1 = none, 0 = complete, 32 = pending, 64 = failed

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -620,6 +620,16 @@ var (
 	uploadProgressLock sync.RWMutex
 )
 
+var defaultUploadMode = "tempfile"
+
+func SetDefaultUploadMode(mode string) {
+	defaultUploadMode = mode
+}
+
+func GetDefaultUploadMode() string {
+	return defaultUploadMode
+}
+
 // GetUploadProgress returns the current upload progress
 func GetUploadProgress() *UploadProgress {
 	uploadProgressLock.RLock()
@@ -959,4 +969,47 @@ func ParseSMSBackupStreaming(userDB *sql.DB, userID string, r io.Reader, batchSi
 	SetUploadProgress(messageCount, messageCount, "completed")
 
 	return messageCount, callCount, nil
+}
+
+// processUploadedFileFromReaderSync is the testable core: parses r into userDB.
+func processUploadedFileFromReaderSync(userID, username string, r io.Reader, userDB *sql.DB) {
+	slog.Info("Starting pipe-mode processing", "user", username)
+
+	messageCount, callCount, err := ParseSMSBackupStreaming(userDB, userID, r, 1)
+	if err != nil {
+		slog.Error("Error processing file", "error", err)
+		SetUploadProgress(0, 0, "error")
+		uploadProgressLock.Lock()
+		if uploadProgress != nil {
+			uploadProgress.mu.Lock()
+			uploadProgress.ErrorMessage = fmt.Sprintf("Failed to process file: %v", err)
+			uploadProgress.mu.Unlock()
+		}
+		uploadProgressLock.Unlock()
+		return
+	}
+
+	slog.Info("Completed pipe-mode processing", "messages", messageCount, "calls", callCount)
+}
+
+// ProcessUploadedFileFromReader processes r in the background without writing a temp file.
+// Intended to be called in a goroutine; the caller is responsible for closing r on error.
+func ProcessUploadedFileFromReader(userID, username string, r io.Reader) {
+	slog.Info("Starting background pipe-mode processing", "user", username)
+
+	userDB, err := GetUserDB(userID, username)
+	if err != nil {
+		slog.Error("Error getting user database", "error", err)
+		SetUploadProgress(0, 0, "error")
+		uploadProgressLock.Lock()
+		if uploadProgress != nil {
+			uploadProgress.mu.Lock()
+			uploadProgress.ErrorMessage = fmt.Sprintf("Failed to get user database: %v", err)
+			uploadProgress.mu.Unlock()
+		}
+		uploadProgressLock.Unlock()
+		return
+	}
+
+	processUploadedFileFromReaderSync(userID, username, r, userDB)
 }

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -771,7 +771,7 @@ func ProcessUploadedFile(userID string, username string, filePath string) {
 	defer file.Close()
 
 	// Process with streaming parser (batch size 1 for minimal memory)
-	messageCount, callCount, err := ParseSMSBackupStreaming(userDB, file, 1) // Insert immediately, no batching
+	messageCount, callCount, err := ParseSMSBackupStreaming(userDB, userID, file, 1) // Insert immediately, no batching
 	if err != nil {
 		slog.Error("Error processing file", "error", err)
 		SetUploadProgress(0, 0, "error")
@@ -790,7 +790,7 @@ func ProcessUploadedFile(userID string, username string, filePath string) {
 
 // ParseSMSBackupStreaming parses SMS backup file with streaming to reduce memory usage
 // Each message is inserted immediately and memory is freed aggressively
-func ParseSMSBackupStreaming(userDB *sql.DB, r io.Reader, batchSize int) (int, int, error) {
+func ParseSMSBackupStreaming(userDB *sql.DB, userID string, r io.Reader, batchSize int) (int, int, error) {
 	// Initialize progress tracking
 	uploadProgressLock.Lock()
 	uploadProgress = &UploadProgress{
@@ -880,6 +880,25 @@ func ParseSMSBackupStreaming(userDB *sql.DB, r io.Reader, batchSize int) (int, i
 				if err != nil {
 					slog.Error("Error converting MMS", "error", err)
 					continue
+				}
+
+				// Offload blob to disk store if configured (MMS only)
+				if msg.MediaData != nil {
+					store := GetUserBlobStore(userID)
+					if disk, ok := store.(*DiskBlobStore); ok {
+						filePath, blobErr := disk.Write(msg.MediaData, msg.MediaType)
+						if blobErr != nil {
+							slog.Warn("Failed to write blob to disk, storing inline", "error", blobErr)
+						} else {
+							if !msg.Date.IsZero() {
+								if err := disk.SetModTime(filePath, msg.Date); err != nil {
+									slog.Warn("Failed to set blob mtime", "path", filePath, "error", err)
+								}
+							}
+							msg.MediaFilePath = filePath
+							msg.MediaData = nil
+						}
+					}
 				}
 
 				// Insert immediately - no batching

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -972,7 +972,7 @@ func ParseSMSBackupStreaming(userDB *sql.DB, userID string, r io.Reader, batchSi
 }
 
 // processUploadedFileFromReaderSync is the testable core: parses r into userDB.
-func processUploadedFileFromReaderSync(userID, username string, r io.Reader, userDB *sql.DB) {
+func processUploadedFileFromReaderSync(userID, username string, r io.ReadCloser, userDB *sql.DB) {
 	slog.Info("Starting pipe-mode processing", "user", username)
 
 	messageCount, callCount, err := ParseSMSBackupStreaming(userDB, userID, r, 1)
@@ -993,12 +993,13 @@ func processUploadedFileFromReaderSync(userID, username string, r io.Reader, use
 }
 
 // ProcessUploadedFileFromReader processes r in the background without writing a temp file.
-// Intended to be called in a goroutine; the caller is responsible for closing r on error.
-func ProcessUploadedFileFromReader(userID, username string, r io.Reader) {
+// Intended to be called in a goroutine. On GetUserDB error, this function closes r.
+func ProcessUploadedFileFromReader(userID, username string, r io.ReadCloser) {
 	slog.Info("Starting background pipe-mode processing", "user", username)
 
 	userDB, err := GetUserDB(userID, username)
 	if err != nil {
+		r.Close()
 		slog.Error("Error getting user database", "error", err)
 		SetUploadProgress(0, 0, "error")
 		uploadProgressLock.Lock()

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -2,7 +2,9 @@ package internal
 
 
 import (
+	"database/sql"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -260,5 +262,51 @@ func TestInvalidXML(t *testing.T) {
 		}
 		// Date "notanumber" should result in Unix epoch
 		t.Logf("Invalid date parsed as: %v", msg.Date)
+	}
+}
+
+func TestDefaultUploadMode(t *testing.T) {
+	// Default should be tempfile
+	if got := GetDefaultUploadMode(); got != "tempfile" {
+		t.Errorf("expected default 'tempfile', got %q", got)
+	}
+}
+
+func TestSetDefaultUploadMode(t *testing.T) {
+	original := GetDefaultUploadMode()
+	defer SetDefaultUploadMode(original)
+
+	SetDefaultUploadMode("pipe")
+	if got := GetDefaultUploadMode(); got != "pipe" {
+		t.Errorf("expected 'pipe', got %q", got)
+	}
+
+	SetDefaultUploadMode("tempfile")
+	if got := GetDefaultUploadMode(); got != "tempfile" {
+		t.Errorf("expected 'tempfile', got %q", got)
+	}
+}
+
+func TestProcessUploadedFileFromReader(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	if err := InitUserDB("test-user", dbPath); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	r := strings.NewReader(sampleXML)
+	// Call directly (not in goroutine) so we can observe results synchronously
+	processUploadedFileFromReaderSync("test-user", "testuser", r, db)
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM messages").Scan(&count); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 messages, got %d", count)
 	}
 }

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -3,6 +3,7 @@ package internal
 
 import (
 	"database/sql"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -300,7 +301,7 @@ func TestProcessUploadedFileFromReader(t *testing.T) {
 	}
 	defer db.Close()
 
-	r := strings.NewReader(sampleXML)
+	r := io.NopCloser(strings.NewReader(sampleXML))
 	// Call directly (not in goroutine) so we can observe results synchronously
 	processUploadedFileFromReaderSync("test-user", "testuser", r, db)
 

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 const sampleXML = `<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 	journalMode   := flag.Bool("journal", false, "Use rollback journal mode instead of WAL (for network filesystems)")
 	blobStorage   := flag.String("blob-storage", "", "Blob storage mode: 'db' (default) or 'disk'")
 	blobDir       := flag.String("blob-dir", "", "Base directory for disk blobs (default: <DB_PATH_PREFIX>/media)")
+	uploadMode    := flag.String("upload-mode", "", "Upload processing mode: 'tempfile' (default) or 'pipe'")
 	flag.Parse()
 
 	// Resolve blob storage config: flags take precedence over env vars
@@ -40,6 +41,19 @@ func main() {
 		fmt.Fprintf(os.Stderr, "invalid --blob-storage value %q: must be 'db' or 'disk'\n", resolvedBlobStorage)
 		os.Exit(1)
 	}
+
+	resolvedUploadMode := *uploadMode
+	if resolvedUploadMode == "" {
+		resolvedUploadMode = os.Getenv("UPLOAD_MODE")
+	}
+	if resolvedUploadMode == "" {
+		resolvedUploadMode = "tempfile"
+	}
+	if resolvedUploadMode != "tempfile" && resolvedUploadMode != "pipe" {
+		fmt.Fprintf(os.Stderr, "invalid --upload-mode value %q: must be 'tempfile' or 'pipe'\n", resolvedUploadMode)
+		os.Exit(1)
+	}
+	internal.SetDefaultUploadMode(resolvedUploadMode)
 
 	dbPathPrefix := os.Getenv("DB_PATH_PREFIX")
 	if dbPathPrefix == "" {
@@ -69,6 +83,8 @@ func main() {
 	} else {
 		logger.Info("Blob storage: db")
 	}
+
+	logger.Info("Upload mode", "mode", resolvedUploadMode)
 
 	// Initialize authentication database
 	authDBPath := filepath.Join(dbPathPrefix, "sbv.db")

--- a/main.go
+++ b/main.go
@@ -22,9 +22,37 @@ var logger *slog.Logger
 func main() {
 	// Parse CLI flags
 	resetPassword := flag.String("reset-password", "", "Reset password for the specified username")
-	listUsers := flag.Bool("list-users", false, "List all users")
-	journalMode := flag.Bool("journal", false, "Use rollback journal mode instead of WAL (for network filesystems)")
+	listUsers     := flag.Bool("list-users", false, "List all users")
+	journalMode   := flag.Bool("journal", false, "Use rollback journal mode instead of WAL (for network filesystems)")
+	blobStorage   := flag.String("blob-storage", "", "Blob storage mode: 'db' (default) or 'disk'")
+	blobDir       := flag.String("blob-dir", "", "Base directory for disk blobs (default: <DB_PATH_PREFIX>/media)")
 	flag.Parse()
+
+	// Resolve blob storage config: flags take precedence over env vars
+	resolvedBlobStorage := *blobStorage
+	if resolvedBlobStorage == "" {
+		resolvedBlobStorage = os.Getenv("BLOB_STORAGE")
+	}
+	if resolvedBlobStorage == "" {
+		resolvedBlobStorage = "db"
+	}
+	if resolvedBlobStorage != "db" && resolvedBlobStorage != "disk" {
+		fmt.Fprintf(os.Stderr, "invalid --blob-storage value %q: must be 'db' or 'disk'\n", resolvedBlobStorage)
+		os.Exit(1)
+	}
+
+	dbPathPrefix := os.Getenv("DB_PATH_PREFIX")
+	if dbPathPrefix == "" {
+		dbPathPrefix = "."
+	}
+
+	resolvedBlobDir := *blobDir
+	if resolvedBlobDir == "" {
+		resolvedBlobDir = os.Getenv("BLOB_DIR")
+	}
+	if resolvedBlobDir == "" {
+		resolvedBlobDir = filepath.Join(dbPathPrefix, "media")
+	}
 
 	// Use WAL mode by default, unless -journal flag is set
 	internal.UseWALMode = !*journalMode
@@ -35,12 +63,15 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
-	// Initialize authentication database
-	dbPathPrefix := os.Getenv("DB_PATH_PREFIX")
-	if dbPathPrefix == "" {
-		dbPathPrefix = "."
+	if resolvedBlobStorage == "disk" {
+		internal.SetGlobalBlobStore(internal.NewDiskBlobStore(resolvedBlobDir))
+		logger.Info("Blob storage: disk", "dir", resolvedBlobDir)
+	} else {
+		logger.Info("Blob storage: db")
 	}
-	authDBPath := dbPathPrefix + "/sbv.db"
+
+	// Initialize authentication database
+	authDBPath := filepath.Join(dbPathPrefix, "sbv.db")
 
 	err := internal.InitAuthDB(authDBPath)
 	if err != nil {
@@ -142,7 +173,10 @@ func main() {
 	}
 
 	// Start auto-import service
-	dataDir := dbPathPrefix + "/data"
+	dataDir := os.Getenv("DATA_DIR")
+	if dataDir == "" {
+		dataDir = filepath.Join(dbPathPrefix, "data")
+	}
 	autoImportService := internal.NewAutoImportService(dataDir)
 	autoImportService.Start()
 	defer autoImportService.Stop()


### PR DESCRIPTION
Allow storing MMS blobs as files on disk instead of embedded in SQLite. Set filename to <hash>.<ext>
Set modified time to the original message's timestamp